### PR TITLE
remove check on number of p tags from test

### DIFF
--- a/test/index.html.test.js
+++ b/test/index.html.test.js
@@ -45,8 +45,7 @@ describe("index.html", () => {
 
     it("has three <p> elements with the correct content", () => {
       const wrapper = document.querySelector("#content");
-      const hint1 = "Wrong number of <p> tag(s) found";
-      expect(content, hint1).to.have.descendants("p").and.have.length(3);
+      expect(content).to.have.descendants("p");
 
       const [firstP, secondP, thirdP] = wrapper.querySelectorAll("p");
       expect(firstP).to.contain.text("Once a mudbrick waystation");
@@ -55,6 +54,7 @@ describe("index.html", () => {
         "The city is divided into 15 municipal districts"
       );
     });
+
 
     it("has three <img> elements with the correct attributes", () => {
       const wrapper = document.querySelector("#content");


### PR DESCRIPTION
Closes #5 

Hi again! We have updated the tests to remove the check on the number of paragraph tags. This should resolve the issue. You can see the changes to the test file here in the lab's GitHub repo.

We apologize for any frustration you might have encountered during this process
but thank you for helping us ensure that those who follow in your path will not!
We appreciate your support!

Thanks again for contributing! 💙